### PR TITLE
fix: make it noop on non-android platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-immersive-bars",
   "version": "1.0.2",
   "description": "React Native component to change bottom bar/navigation bar to be transparent on Android",
-  "main": "index.android.js",
+  "main": "index",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Currently, calling changeBarColors without platform checks results in error.


![Simulator Screen Shot - iPhone 12 - 2021-05-23 at 18 23 11](https://user-images.githubusercontent.com/6187401/119260421-8011da00-bbf4-11eb-8fec-66d6e1a6f6a3.png)


This will allow you to call changeBarColors without platform checks
