### PR TITLE
Replace `jcenter` with `mavenCentral` and update `gradle` plugin. 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,12 +4,12 @@ def getExtOrDefault(name, defaultValue) {
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath("com.android.tools.build:gradle:7.2.1")
     }
 }
 
@@ -30,9 +30,9 @@ android {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
     google()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Hi, @crutchcorn !

Thank you for creating the library. I've been using it since last year in many of my projects and also included this in my starter template (https://github.com/kuasha420/react-native-template-ts-plus). 

I've noticed that the android build was failing for me since the shutdown of `jcenter`. I've updated the repositories in the `build.gradle` file to match `react-native` upstream and that seemed to have fixed the issue and the package is working. 

What do you think? 

Cheers. 